### PR TITLE
Ensure that rejects inside new Promise are passed up

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-JSON Crud v1.0.0
+JSON Crud v1.0.1
 =========================
 A simple CRUD JSON database using either a JSON file or a folder of JSON files.
 
@@ -110,7 +110,7 @@ declare namespace JsonDB {
      * @returns {Promise} A promise that will resolve with an array containing
      *   keys of the updated data.
      */
-    update: (data: Data, filter: Filter | boolean) => Promise<IdOrError[]>;
+    update: (data: Data, filter: boolean) => Promise<IdOrError[]>;
     /**
      * Updates data in the JSON database. Data can either be given as
      * key-value parameter pairs, OR if the key field has been specified Object

--- a/lib/JsonFileDB.js
+++ b/lib/JsonFileDB.js
@@ -282,6 +282,8 @@ module.exports = function JsonFileDB(file, options) {
         } else {
           readData().then(function(data) {
             resolve(data);
+          }).catch(function(error) {
+            reject(error);
           });
         }
         return;
@@ -315,6 +317,8 @@ module.exports = function JsonFileDB(file, options) {
           }, function(err) {
             reject(err);
           });
+        }).catch(function(error) {
+          reject(error);
         });
 
         return;
@@ -332,8 +336,8 @@ module.exports = function JsonFileDB(file, options) {
 
       promise.then(function(data) {
         resolve(data);
-      }, function(err) {
-        reject(err);
+      }).catch(function(error) {
+        reject(error);
       });
     });
   }
@@ -392,7 +396,7 @@ module.exports = function JsonFileDB(file, options) {
           keysPromise = readKeys();
         }
 
-        return keysPromise.then(function(existingKeys) {
+        keysPromise.then(function(existingKeys) {
           void 0;
           if (options.cacheValues) {
             cachedData = {};
@@ -404,7 +408,11 @@ module.exports = function JsonFileDB(file, options) {
           saveData({}).then(function() {
             resolve(existingKeys);
           });
+        }).catch(function(error) {
+          reject(error);
         });
+
+        return;
       } else if (common.keyTypes.indexOf(typeof filter) !== -1) {
         filter = [filter];
       } else if (filter instanceof Array) {
@@ -418,16 +426,16 @@ module.exports = function JsonFileDB(file, options) {
 
         dataPromise.then(function(data) {
           var deletedKeys = [];
-          common.processFilter(data, filter, function(id) {
+          return common.processFilter(data, filter, function(id) {
             deletedKeys.push(id);
             delete data[id];
           }).then(function() {
             return saveData(data);
           }).then(function() {
             resolve(deletedKeys);
-          }, function(err) {
-            reject(err);
           });
+        }).catch(function(error) {
+          reject(error);
         });
 
         return;
@@ -474,6 +482,8 @@ module.exports = function JsonFileDB(file, options) {
           resolve(deletedIds);
           return Promise.resolve();
         });
+      }).catch(function(error) {
+        reject(error);
       });
     });
 

--- a/lib/JsonFolderDB.js
+++ b/lib/JsonFolderDB.js
@@ -492,8 +492,11 @@ module.exports = function JsonFolderDB(file, options) {
         } else {
           readData().then(function(data) {
             resolve(data);
+          }).catch(function(error) {
+            reject(error);
           });
         }
+        return;
       } else if (typeof filter !== 'object') {
         reject(new Error('filter needs to be a key, an array of keys or a '
             + 'filter Object'));
@@ -504,8 +507,8 @@ module.exports = function JsonFolderDB(file, options) {
             fetchedData[id] = itemData;
           }).then(function() {
             resolve(fetchedData);
-          }, function(err) {
-            reject(err);
+          }).catch(function(error) {
+            reject(error);
           });
         } else {
           var keysPromise;
@@ -528,6 +531,8 @@ module.exports = function JsonFolderDB(file, options) {
             Promise.all(fetchPromises).then(function() {
               resolve(fetchedData);
             });
+          }).catch(function(error) {
+            reject(error);
           });
         }
         return;
@@ -536,6 +541,8 @@ module.exports = function JsonFolderDB(file, options) {
       // Get values for keys
       return getValues(filter, expectSingle).then(function(data) {
         resolve(data);
+      }).catch(function(error) {
+        reject(error);
       });
     });
   }
@@ -560,7 +567,7 @@ module.exports = function JsonFolderDB(file, options) {
       } else if (filter === true || typeof filter === 'object') {
         void 0;
         // Get the existing keys
-        return readKeys().then(function(existingKeys) {
+        readKeys().then(function(existingKeys) {
           void 0;
           if (filter === true) {
             deletedKeys = existingKeys;
@@ -607,8 +614,12 @@ module.exports = function JsonFolderDB(file, options) {
               cachedKeys = [];
             }
             resolve(deletedKeys);
-          }, reject);
+          });
+        }).catch(function(error) {
+          reject(error);
         });
+
+        return;
       } else {
         reject({
           message: 'filter needs to be an object containing a filter'
@@ -648,6 +659,8 @@ module.exports = function JsonFolderDB(file, options) {
           }
           resolve(deletedKeys);
         });
+      }).catch(function(error) {
+        reject(error);
       });
     });
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-crud",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A simple CRUD JSON database using either a JSON file or a folder of JSON files.",
   "main": "json-crud.js",
   "types": "src/typings/json-crud.d.ts",

--- a/src/lib/JsonFileDB.js
+++ b/src/lib/JsonFileDB.js
@@ -282,6 +282,8 @@ module.exports = function JsonFileDB(file, options) {
         } else {
           readData().then(function(data) {
             resolve(data);
+          }).catch(function(error) {
+            reject(error);
           });
         }
         return;
@@ -315,6 +317,8 @@ module.exports = function JsonFileDB(file, options) {
           }, function(err) {
             reject(err);
           });
+        }).catch(function(error) {
+          reject(error);
         });
 
         return;
@@ -332,8 +336,8 @@ module.exports = function JsonFileDB(file, options) {
 
       promise.then(function(data) {
         resolve(data);
-      }, function(err) {
-        reject(err);
+      }).catch(function(error) {
+        reject(error);
       });
     });
   }
@@ -392,7 +396,7 @@ module.exports = function JsonFileDB(file, options) {
           keysPromise = readKeys();
         }
 
-        return keysPromise.then(function(existingKeys) {
+        keysPromise.then(function(existingKeys) {
           console.log('delete got existing keys', existingKeys);
           if (options.cacheValues) {
             cachedData = {};
@@ -404,7 +408,11 @@ module.exports = function JsonFileDB(file, options) {
           saveData({}).then(function() {
             resolve(existingKeys);
           });
+        }).catch(function(error) {
+          reject(error);
         });
+
+        return;
       } else if (common.keyTypes.indexOf(typeof filter) !== -1) {
         filter = [filter];
       } else if (filter instanceof Array) {
@@ -418,16 +426,16 @@ module.exports = function JsonFileDB(file, options) {
 
         dataPromise.then(function(data) {
           var deletedKeys = [];
-          common.processFilter(data, filter, function(id) {
+          return common.processFilter(data, filter, function(id) {
             deletedKeys.push(id);
             delete data[id];
           }).then(function() {
             return saveData(data);
           }).then(function() {
             resolve(deletedKeys);
-          }, function(err) {
-            reject(err);
           });
+        }).catch(function(error) {
+          reject(error);
         });
 
         return;
@@ -474,6 +482,8 @@ module.exports = function JsonFileDB(file, options) {
           resolve(deletedIds);
           return Promise.resolve();
         });
+      }).catch(function(error) {
+        reject(error);
       });
     });
 

--- a/src/lib/JsonFolderDB.js
+++ b/src/lib/JsonFolderDB.js
@@ -492,8 +492,11 @@ module.exports = function JsonFolderDB(file, options) {
         } else {
           readData().then(function(data) {
             resolve(data);
+          }).catch(function(error) {
+            reject(error);
           });
         }
+        return;
       } else if (typeof filter !== 'object') {
         reject(new Error('filter needs to be a key, an array of keys or a '
             + 'filter Object'));
@@ -504,8 +507,8 @@ module.exports = function JsonFolderDB(file, options) {
             fetchedData[id] = itemData;
           }).then(function() {
             resolve(fetchedData);
-          }, function(err) {
-            reject(err);
+          }).catch(function(error) {
+            reject(error);
           });
         } else {
           var keysPromise;
@@ -528,6 +531,8 @@ module.exports = function JsonFolderDB(file, options) {
             Promise.all(fetchPromises).then(function() {
               resolve(fetchedData);
             });
+          }).catch(function(error) {
+            reject(error);
           });
         }
         return;
@@ -536,6 +541,8 @@ module.exports = function JsonFolderDB(file, options) {
       // Get values for keys
       return getValues(filter, expectSingle).then(function(data) {
         resolve(data);
+      }).catch(function(error) {
+        reject(error);
       });
     });
   }
@@ -560,7 +567,7 @@ module.exports = function JsonFolderDB(file, options) {
       } else if (filter === true || typeof filter === 'object') {
         console.log('object/true delete handler');
         // Get the existing keys
-        return readKeys().then(function(existingKeys) {
+        readKeys().then(function(existingKeys) {
           console.log('existing keys are', existingKeys);
           if (filter === true) {
             deletedKeys = existingKeys;
@@ -607,8 +614,12 @@ module.exports = function JsonFolderDB(file, options) {
               cachedKeys = [];
             }
             resolve(deletedKeys);
-          }, reject);
+          });
+        }).catch(function(error) {
+          reject(error);
         });
+
+        return;
       } else {
         reject({
           message: 'filter needs to be an object containing a filter'
@@ -648,6 +659,8 @@ module.exports = function JsonFolderDB(file, options) {
           }
           resolve(deletedKeys);
         });
+      }).catch(function(error) {
+        reject(error);
       });
     });
   }


### PR DESCRIPTION
- Ensure that any rejections of promises inside of new Promise are
  passed up to the new Promise
- Ensure all catches are handled the same
- Fixed bug in JsonFolderDB where given a null filter, it was not
  returning after retrieving all the values